### PR TITLE
Comment counter test

### DIFF
--- a/src/modules/comments.js
+++ b/src/modules/comments.js
@@ -5,7 +5,7 @@ export default class Comments {
 
   comments = [];
 
-  add = async (comment = {}) => {
+  add = async (comment = {}, id = null) => {
     const results = await fetch(`${this.baseUrl}apps/${this.appId}/comments`, {
       method: 'POST',
       body: JSON.stringify(comment),
@@ -13,6 +13,9 @@ export default class Comments {
         'Content-type': 'application/json; charset=UTF-8',
       },
     });
+    if (id != null) {
+      await this.get(id);
+    }
     return results;
   };
 
@@ -20,6 +23,7 @@ export default class Comments {
     const data = await fetch(`${this.baseUrl}apps/${this.appId}/comments?item_id=${id}`, { method: 'GET' });
     const commentsData = await data.json();
     this.comments = commentsData;
+    return this.comments;
   };
 
   commentCount = () => (this.comments.length === undefined ? 0 : this.comments.length);

--- a/src/style.css
+++ b/src/style.css
@@ -95,7 +95,7 @@ button:active {
   margin: auto;
   padding: 20px;
   width: 80%;
-  height: 80vh;
+  height: 100%;
   border-radius: 20px;
   max-width: 1000px;
   overflow-y: auto;

--- a/src/unit_tests/comments_counter.test.js
+++ b/src/unit_tests/comments_counter.test.js
@@ -1,4 +1,4 @@
-import Comments from '../src/modules/comments.js';
+import Comments from '../modules/comments.js';
 
 const comments = new Comments();
 const mockData = [

--- a/tests/comments_counter.test.js
+++ b/tests/comments_counter.test.js
@@ -1,0 +1,26 @@
+import Comments from '../src/modules/comments.js';
+
+const comments = new Comments();
+const mockData = [
+  {
+    comment: 'This is nice!',
+    creation_date: '2021-01-10',
+    username: 'John',
+  },
+  {
+    comment: 'Great content!',
+    creation_date: '2021-02-10',
+    username: 'Jane',
+  },
+];
+global.fetch = jest.fn(() => Promise.resolve({
+  json: () => Promise.resolve(mockData),
+}));
+
+describe('Get comments the the length', () => {
+  test('2 Comment added count should be 2', async () => {
+    await comments.get('test');
+
+    expect(comments.commentCount()).toBe(2);
+  });
+});


### PR DESCRIPTION
Hello @awais-amjed ,
In this PR, I was able to achieve the following:

- [x] Mock `fetch` to mimic the comments API call and retrieve data.
- [x] Test on the mock data by calling the comments counter `function`